### PR TITLE
Create new department template

### DIFF
--- a/app/assets/stylesheets/departments.scss
+++ b/app/assets/stylesheets/departments.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Departments controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+
   add_flash_types :info, :error, :warning, :success
 
   def login?
@@ -10,7 +11,11 @@ class ApplicationController < ActionController::Base
   end
 
   def authenticate
-    redirect_to login_path, error: "Log in to access this page" if login?
+    if login?
+      redirect_to login_path, error: "Log in to access this page"
+      return
+    end
+    set_current_employee
   end
 
   private

--- a/app/controllers/departments_controller.rb
+++ b/app/controllers/departments_controller.rb
@@ -1,0 +1,7 @@
+class DepartmentsController < ApplicationController
+  before_action :authenticate
+
+  def new
+    @department = Department.new
+  end
+end

--- a/app/helpers/departments_helper.rb
+++ b/app/helpers/departments_helper.rb
@@ -1,0 +1,2 @@
+module DepartmentsHelper
+end

--- a/app/views/departments/new.html.erb
+++ b/app/views/departments/new.html.erb
@@ -1,0 +1,5 @@
+<%= form_with model: @department, html: {autocomplete: "off"} do |f| %>
+  <%= f.text_field :department, placeholder: "Department name" %>
+  <%= f.text_field :manager, placeholder: "Manager" %>
+  <%= f.submit "Create new department" %>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -11,9 +11,14 @@
     <% end  %>
   </div>
   <div id="right-items">
-    <span id="create-user">
+    <span id="create-employee">
       <%= link_to new_employee_path do%>
         <i class="fa-solid fa-user-plus"></i>
+      <% end %>
+    </span>
+    <span id="create-department">
+      <%= link_to new_department_path do%>
+        <i class="fa-solid fa-people-group"></i>
       <% end %>
     </span>
     <ul id="reports">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   resources :employees
+  resources :departments, only: [:new, :create, :update, :destroy]
 
   root 'dashboard#home'
 

--- a/test/controllers/departments_controller_test.rb
+++ b/test/controllers/departments_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DepartmentsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
The template to create a new department is now completed, was created the controller 'departments' to manage this actions. In this controller was created a method to render the new template with an instance for a new department.

Also, was created the 'new.html.rb' that containse the required for to create a new department for @department model.

The routes was created as resoucers, due to the HR could create, update, or delete a department.

Finally, was created the respective link to the 'new_department_path' and was appended an icon that represents the department, in this same template, was change the id for the 'new employee' icon from 'create-user' to 'create-employee'.