### PR TITLE
Checker view fixed issue

### DIFF
--- a/app/controllers/employee_schedules_controller.rb
+++ b/app/controllers/employee_schedules_controller.rb
@@ -26,25 +26,26 @@ class EmployeeSchedulesController < ApplicationController
   end
 
   def employee_arrived
-    @employee.employee_schedule
+    @employee.employee_schedules.group_by {|c| c.check_in.to_date == @check_time.to_date}.any?
   end
 
   def check_in
-    @employee_schedule = @employee.build_employee_schedule(check_in: @check_time)
+    @employee_schedule = @employee.employee_schedules.new(check_in: @check_time)
   end
 
   def check_out
-    @employee_schedule = @employee.employee_schedule.update(checkout: @check_time)
+    @employee_schedule = @employee.employee_schedules.update(checkout: @check_time)
   end
 
   def check_in_validations
     return true unless employee_arrived
-    raise "#{@employee.name}, you already checked in at: #{@check_time}" unless @employee.employee_schedule.check_in.nil?
+    raise "#{@employee.name}, you completed your schedule for today, please come back tommorrow!" unless employee_arrived == true && @employee.employee_schedules.where(check_in: @check_time).first.nil?
+    raise "#{@employee.name}, you can't check in again without a check out first" if employee_arrived
   end
 
   def check_out_validations
+    raise "#{@employee.name}, you completed your schedule for today, please come back tommorrow!" if employee_arrived && @employee.employee_schedules.first.checkout.nil? == false
     raise "#{@employee.name}, you cannot check out if you don't check in first, please check in." unless employee_arrived
-    raise "#{@employee.name}, you completed your schedule for today, please come back tommorrow!" if  @employee.employee_schedule.check_in.nil? == false && @employee.employee_schedule.checkout.nil? == false
   end
 
   private

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -2,7 +2,7 @@ class Employee < ApplicationRecord
   has_secure_password
 
   belongs_to :department, class_name: "Department", foreign_key: "department_id"
-  has_one :employee_schedule
+  has_many :employee_schedules
 
   validates :password, confirmation: true, on: :create
   validates :password_confirmation, presence: true, on: :create

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,7 @@ module TimeClock
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "America/Mexico_City"
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end


### PR DESCRIPTION
To solve the issue that an employee only could have a single employee schedule was necessary the next:

- The first step was change the association "has-one and belongs-to" to "has-many and bleongs-to", by this way, an employee can have many employee schedules, that reperestens the check in and check out.
- During this resolution, was identified that Rails was storing the datetime fields in a different time zone, thats why was changed the time zone in the application.rb to "America/Mexico_city".
- Finally, was changed some validations due to an employee could make multiplies check in without a check out during the same day.