### PR TITLE
See more detailed information error

### DIFF
--- a/app/views/employees/analysis.html.erb
+++ b/app/views/employees/analysis.html.erb
@@ -17,13 +17,10 @@
     </div>
     <div class="arrived-time-status" id="arrived-time-status">
       <div id="check_in">
-        <%= "check_in: #{@employee_arrived_time.check_in}" %>
+        <%= @employee_arrived_time.checkout ? "check_in: #{@employee_arrived_time.check_in.strftime("%d-%m-%y at %H:%m")}" : "check_in: --"  %>
       </div>
       <div id="checkout">
-        <%= @employee_arrived_time.checkout ? "check_out: #{@employee_arrived_time.checkout}" : "check_out: --"  %>
-      </div>
-      <div id="lunch">
-        <%= @employee_arrived_time.lunch %>
+        <%= @employee_arrived_time.checkout ? "check_out: #{@employee_arrived_time.checkout.strftime("%d-%m-%y at %H:%m")}" : "check_out: --"  %>
       </div>
     </div>
     <div class="other-information" id="other-information">


### PR DESCRIPTION
The error showed when click on 'see more detailed infromtion' comes form the path /analysis/employee/:employee_name, the problem was that the field 'lunch' was removed from the table employee_schedules, so the solution was only remove that field.